### PR TITLE
Using shared_examples to test concern

### DIFF
--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,16 +1,18 @@
-example_id                                            | status | run_time        |
------------------------------------------------------ | ------ | --------------- |
-./spec/unit/models/inventory_spec.rb[1:1:1:1:1]       | passed | 0.07123 seconds |
-./spec/unit/models/inventory_spec.rb[1:1:1:2:1]       | passed | 0.04699 seconds |
-./spec/unit/models/inventory_spec.rb[1:1:2:1:1]       | passed | 0.0345 seconds  |
-./spec/unit/models/inventory_spec.rb[1:1:2:2:1]       | passed | 0.02921 seconds |
-./spec/unit/models/item_spec.rb[1:1:1:1]              | passed | 0.01323 seconds |
-./spec/unit/models/survivor_observer_spec.rb[1:1]     | passed | 0.06857 seconds |
-./spec/unit/models/survivor_spec.rb[1:1:1:1]          | passed | 0.90761 seconds |
-./spec/unit/models/survivor_spec.rb[1:1:1:2]          | passed | 0.05327 seconds |
-./spec/unit/models/survivor_spec.rb[1:1:1:3]          | passed | 0.0388 seconds  |
-./spec/unit/use_cases/infection_report_spec.rb[1:1:1] | passed | 0.01249 seconds |
-./spec/unit/use_cases/infection_report_spec.rb[1:1:2] | passed | 0.03509 seconds |
-./spec/unit/use_cases/infection_report_spec.rb[1:1:3] | passed | 0.07762 seconds |
-./spec/unit/use_cases/infection_report_spec.rb[1:2:1] | passed | 0.07187 seconds |
-./spec/unit/use_cases/infection_report_spec.rb[1:2:2] | passed | 0.08001 seconds |
+example_id                                                                | status | run_time        |
+------------------------------------------------------------------------- | ------ | --------------- |
+./spec/unit/models/concerns/infection_report_state_machine_spec.rb[1:1:1] | passed | 0.0427 seconds  |
+./spec/unit/models/concerns/infection_report_state_machine_spec.rb[1:1:2] | passed | 0.00355 seconds |
+./spec/unit/models/inventory_spec.rb[1:1:1:1:1]                           | passed | 0.04004 seconds |
+./spec/unit/models/inventory_spec.rb[1:1:1:2:1]                           | passed | 0.02199 seconds |
+./spec/unit/models/inventory_spec.rb[1:1:2:1:1]                           | passed | 0.04448 seconds |
+./spec/unit/models/inventory_spec.rb[1:1:2:2:1]                           | passed | 0.05321 seconds |
+./spec/unit/models/item_spec.rb[1:1:1:1]                                  | passed | 0.01736 seconds |
+./spec/unit/models/survivor_observer_spec.rb[1:1]                         | passed | 0.99908 seconds |
+./spec/unit/models/survivor_spec.rb[1:1:1:1]                              | passed | 0.03801 seconds |
+./spec/unit/models/survivor_spec.rb[1:1:1:2]                              | passed | 0.05916 seconds |
+./spec/unit/models/survivor_spec.rb[1:1:1:3]                              | passed | 0.07203 seconds |
+./spec/unit/use_cases/infection_report_spec.rb[1:1:1]                     | passed | 0.02722 seconds |
+./spec/unit/use_cases/infection_report_spec.rb[1:1:2]                     | passed | 0.04189 seconds |
+./spec/unit/use_cases/infection_report_spec.rb[1:1:3]                     | passed | 0.0353 seconds  |
+./spec/unit/use_cases/infection_report_spec.rb[1:2:1]                     | passed | 0.06776 seconds |
+./spec/unit/use_cases/infection_report_spec.rb[1:2:2]                     | passed | 0.09088 seconds |

--- a/spec/unit/models/concerns/infection_report_state_machine_spec.rb
+++ b/spec/unit/models/concerns/infection_report_state_machine_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# We are using shared_examples to test module behavior
+RSpec.shared_examples 'an_infection_report_state_machine' do
+  before(:all) do
+    @class_that_includes_concern = described_class
+    @intance_of_class_that_includes_concern = FactoryBot.build(@class_that_includes_concern.to_s.underscore.to_sym)
+  end
+
+  it 'should have reports states' do
+    expect(@intance_of_class_that_includes_concern).to have_state :zero_reports
+  end
+  
+  it 'should allow event report_as_infected' do
+    expect(@intance_of_class_that_includes_concern).to allow_event :report_as_infected
+  end
+end
+
+# In order to test Concern, we need to includes it on some model
+RSpec.describe Survivor do
+  it_behaves_like 'an_infection_report_state_machine'
+end


### PR DESCRIPTION
Using shared_examples approach to test survivor infection concern behavior
In order to test Concern, we need to includes it on some model
